### PR TITLE
Update gradio_client version in requirements.txt

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -2,7 +2,7 @@ attrdict
 einops==0.7.0
 fairseq==0.12.2
 gradio==4.11.0
-gradio_client==0.7.1
+gradio_client==0.7.3
 huggingface-hub==0.19.4
 hydra-core==1.0.7
 mediapy==1.2.0


### PR DESCRIPTION
The gradio_client version specified in the requirements is not compatible with the gradio version. I initially got the error: 

`
ERROR: Cannot install -r requirements.txt (line 4) and gradio_client==0.7.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested gradio_client==0.7.1
    gradio 4.11.0 depends on gradio-client==0.7.3
`